### PR TITLE
Minor fix for build in coupled configuration

### DIFF
--- a/src/IPE_Wrapper.F90
+++ b/src/IPE_Wrapper.F90
@@ -52,7 +52,7 @@ CONTAINS
       rcToReturn=rc) ) RETURN  ! bail out
 
     ! Build IPE
-    CALL ipe % Build(mpi_comm=mpicomm, rc=localrc)
+    CALL ipe % Build(comm=mpicomm, rc=localrc)
     IF( localrc /= IPE_SUCCESS ) THEN
       CALL ESMF_LogSetError(ESMF_RC_INTNRL_BAD, msg="Error building IPE", &
         line=__LINE__, &


### PR DESCRIPTION
This PR aims to fix following build issue with coupling,

```
mpiifort -DPACKAGE_NAME=\"ipe\" -DPACKAGE_TARNAME=\"ipe\" -DPACKAGE_VERSION=\"0.0.1\" -DPACKAGE_STRING=\"ipe\ 0.0.1\" -DPACKAGE_BUGREPORT=\"ipe_devteam@noaa.gov\" -DPACKAGE_URL=\"\" -DPACKAGE=\"ipe\" -DVERSION=\"0.0.1\" -DHAVE_MPI=1 -DHAVE_COMIO=1 -DHAVE_ESMF=1 -I.    -I ipelib -I ipelib/dynamo -I ipelib/empirical_efield -I ipelib/flip -I ipelib/msise00 -I ipelib/shared -I/work2/noaa/nems/tufuk/NASA/COMIO/install/include -I/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env/install/intel/2021.9.0/parallel-netcdf-1.12.2-x3m7oy3/include  -g -O2 -fp-model source -ftz -align array64byte -xCORE-AVX2 -qno-opt-dynamic-align -c -o libipm_a-IPE_Wrapper.o `test -f 'IPE_Wrapper.F90' || echo './'`IPE_Wrapper.F90
IPE_Wrapper.F90(55): error #6627: This is an actual argument keyword name, and not a dummy argument name.   [MPI_COMM]
    CALL ipe % Build(mpi_comm=mpicomm, rc=localrc)
---------------------^
compilation aborted for IPE_Wrapper.F90 (code 1)
make[2]: *** [Makefile:538: libipm_a-IPE_Wrapper.o] Error 1
``` 

In this case, I am using ESMF 8.6.0 and spack-stack environment on MSU Hercules.  For your reference, here are my steps:

```
module use /work2/noaa/nems/tufuk/NASA/modulefiles
module load ufs_hercules.intel
module li

git clone -b feature/spack-stack https://github.com/NOAA-SWPC/COMIO.git
cd COMIO
./configure --prefix=/work2/noaa/nems/tufuk/NASA/COMIO/install
make
make install

git clone https://github.com/sword-swx-coe/IPE.git
cd IPE
./configure --prefix=/work2/noaa/nems/tufuk/NASA/IPE/install --enable-coupling --with-comio=/work2/noaa/nems/tufuk/NASA/COMIO/install --with-esmf=/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env/install/intel/2021.9.0/esmf-8.6.0-rqrapep
make
make install
```